### PR TITLE
Put absolute urls in plunker and jsfiddle

### DIFF
--- a/docs/js/docs.js
+++ b/docs/js/docs.js
@@ -120,7 +120,7 @@ docsApp.directive.sourceEdit = function(getEmbeddedTemplate) {
 };
 
 
-docsApp.serviceFactory.loadedUrls = function($document, versionedFiles) {
+docsApp.serviceFactory.loadedUrls = function($document, $window, versionedFiles) {
   var urls = {};
 
   angular.forEach($document.find('script'), function(script) {
@@ -139,7 +139,7 @@ docsApp.serviceFactory.loadedUrls = function($document, versionedFiles) {
   });
 
   angular.forEach(versionedFiles.files, function(file) {
-    urls.base.push(file.src);
+    urls.base.push(file.src.indexOf('/') === 0 ? $window.location.origin + file.src : file.src);
   });
 
   return urls;


### PR DESCRIPTION
Script references to versionedFiles were not working in editable plunks, because they were relative paths.
